### PR TITLE
Fix: move fun ratings logic to react

### DIFF
--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -5,17 +5,6 @@ class RegionsController < ApplicationController
 
   def show
     @region = Region.find(params[:id])
-    raw_restaurants = @region.restaurants.order(rating: :desc)
-    @restaurants = transform_rating(raw_restaurants)
-  end
-
-  protected
-
-  def transform_rating(restaurants)
-    str_ratings = ["avoid", "meh", "good", "great", "AMAZE"]
-
-    restaurants.each do |restaurant|
-      restaurant.rating = str_ratings[restaurant.rating.to_i - 1]
-    end
+    @restaurants = @region.restaurants.order(rating: :desc)
   end
 end

--- a/app/javascript/components/RestaurantView.js
+++ b/app/javascript/components/RestaurantView.js
@@ -1,17 +1,22 @@
-import React, { useState } from "react";
-import deleteRestaurant from "../helpers/deleteRestaurant";
+import React, { useState, useEffect } from "react";
 import TableView from "./restaurantViews/TableView";
 import CardView from "./restaurantViews/CardView";
+import deleteRestaurant from "../helpers/deleteRestaurant";
+import transformRatings from "../helpers/transformRatings";
 
 const RestaurantView = (props) => {
-  const { isAdmin } = props;
+  const { isAdmin, allRestaurants } = props;
 
   const [viewType, setViewType] = useState("card");
-  const [restaurants, setrestaurants] = useState(props.restaurants);
+  const [restaurants, setRestaurants] = useState(allRestaurants);
+
+  useEffect(() => {
+    setRestaurants(transformRatings(restaurants))
+  }, [])
 
   const deleteRestaurantFunction = (restaurantId) => {
     deleteRestaurant(restaurantId);
-    setrestaurants(
+    setRestaurants(
       restaurants.filter((restaurant) => restaurant.id != restaurantId)
     );
   };

--- a/app/javascript/helpers/transformRatings.js
+++ b/app/javascript/helpers/transformRatings.js
@@ -1,0 +1,28 @@
+const transformRatings = (restaurants) => {
+  const transformedRestaurants = restaurants.map((restaurant) => {
+    switch (restaurant.rating) {
+      case "1":
+        restaurant.rating = "avoid";
+        break;
+      case "2":
+        restaurant.rating = "meh";
+        break;
+      case "3":
+        restaurant.rating = "good";
+        break;
+      case "4":
+        restaurant.rating = "great";
+        break;
+      case "5":
+        restaurant.rating = "AMAZE";
+        break;
+      default:
+        break;
+    }
+    return restaurant;
+  });
+
+  return transformedRestaurants;
+};
+
+export default transformRatings;

--- a/app/views/regions/show.html.haml
+++ b/app/views/regions/show.html.haml
@@ -5,7 +5,7 @@
 
 .section 
   .container
-    = react_component("RestaurantView", { restaurants: @restaurants, isAdmin: admin_signed_in? } )
+    = react_component("RestaurantView", { allRestaurants: @restaurants, isAdmin: admin_signed_in? } )
 
 - if admin_signed_in?
   .section 


### PR DESCRIPTION
After shipping funner ratings there was a bug that showed ratings as "0" only on production.
By moving that "renaming" logic to the react side (and out of the rails controller), I'm hoping the concerns will be separated better. 

Rails -> sees ratings on a scale of 1 - 5
React -> transforms ratings to AVOID - AMAZE scale